### PR TITLE
Add basic routing and placeholder pages

### DIFF
--- a/my-app/package.json
+++ b/my-app/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^6.23.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/my-app/src/APropos.js
+++ b/my-app/src/APropos.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function APropos() {
+  return (
+    <div>
+      <h2>À propos</h2>
+      <p>À propos de nous.</p>
+    </div>
+  );
+}
+
+export default APropos;

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,24 +1,33 @@
-import logo from './logo.svg';
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import Services from './Services';
+import Realisations from './Realisations';
+import APropos from './APropos';
+import Contact from './Contact';
 import './App.css';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Router>
+      <div className="App">
+        <nav>
+          <ul>
+            <li><Link to="/">Accueil</Link></li>
+            <li><Link to="/services">Services</Link></li>
+            <li><Link to="/realisations">Réalisations</Link></li>
+            <li><Link to="/apropos">À propos</Link></li>
+            <li><Link to="/contact">Contact</Link></li>
+          </ul>
+        </nav>
+        <Routes>
+          <Route path="/" element={<div>Bienvenue sur notre site</div>} />
+          <Route path="/services" element={<Services />} />
+          <Route path="/realisations" element={<Realisations />} />
+          <Route path="/apropos" element={<APropos />} />
+          <Route path="/contact" element={<Contact />} />
+        </Routes>
+      </div>
+    </Router>
   );
 }
 

--- a/my-app/src/Contact.js
+++ b/my-app/src/Contact.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Contact() {
+  return (
+    <div>
+      <h2>Contact</h2>
+      <p>Contactez-nous.</p>
+    </div>
+  );
+}
+
+export default Contact;

--- a/my-app/src/Realisations.js
+++ b/my-app/src/Realisations.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Realisations() {
+  return (
+    <div>
+      <h2>Réalisations</h2>
+      <p>Nos réalisations.</p>
+    </div>
+  );
+}
+
+export default Realisations;

--- a/my-app/src/Services.js
+++ b/my-app/src/Services.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Services() {
+  return (
+    <div>
+      <h2>Services</h2>
+      <p>Nos services.</p>
+    </div>
+  );
+}
+
+export default Services;


### PR DESCRIPTION
## Summary
- add react-router-dom dependency
- create placeholder pages: Services, Réalisations, À propos, Contact
- wire up routes and navigation in App

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b57fc650188320b711e95ff2cafba1