### PR TITLE
feat: add admin login and dashboard

### DIFF
--- a/my-app/src/AdminLogin.js
+++ b/my-app/src/AdminLogin.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const LOGIN_URL = 'http://localhost:5000/login';
+
+function AdminLogin({ onLogin }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await fetch(LOGIN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (!response.ok) {
+        throw new Error('Erreur de connexion');
+      }
+      const data = await response.json();
+      localStorage.setItem('token', data.token);
+      onLogin && onLogin(data.token);
+      navigate('/dashboard');
+    } catch (err) {
+      console.error('Erreur connexion', err);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="admin-login-form">
+      <h2>Connexion Admin</h2>
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        placeholder="Mot de passe"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button type="submit">Se connecter</button>
+    </form>
+  );
+}
+
+export default AdminLogin;

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,12 +1,27 @@
-import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import React, { useState } from 'react';
+import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import Services from './Services';
 import Realisations from './Realisations';
 import APropos from './APropos';
 import Contact from './pages/Contact';
+import AdminLogin from './AdminLogin';
+import Dashboard from './Dashboard';
+import RealisationFormPage from './RealisationFormPage';
 import './App.css';
 
 function App() {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+
+  const handleLogin = (tok) => {
+    localStorage.setItem('token', tok);
+    setToken(tok);
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
   return (
     <Router>
       <div className="App">
@@ -17,6 +32,12 @@ function App() {
             <li><Link to="/realisations">Réalisations</Link></li>
             <li><Link to="/apropos">À propos</Link></li>
             <li><Link to="/contact">Contact</Link></li>
+            {token && <li><Link to="/dashboard">Admin</Link></li>}
+            {token && (
+              <li>
+                <button onClick={handleLogout}>Déconnexion</button>
+              </li>
+            )}
           </ul>
         </nav>
         <Routes>
@@ -25,6 +46,19 @@ function App() {
           <Route path="/realisations" element={<Realisations />} />
           <Route path="/apropos" element={<APropos />} />
           <Route path="/contact" element={<Contact />} />
+          <Route path="/admin/login" element={<AdminLogin onLogin={handleLogin} />} />
+          <Route
+            path="/dashboard"
+            element={token ? <Dashboard /> : <Navigate to="/admin/login" />}
+          />
+          <Route
+            path="/dashboard/new"
+            element={token ? <RealisationFormPage /> : <Navigate to="/admin/login" />}
+          />
+          <Route
+            path="/dashboard/edit/:id"
+            element={token ? <RealisationFormPage /> : <Navigate to="/admin/login" />}
+          />
         </Routes>
       </div>
     </Router>

--- a/my-app/src/Dashboard.js
+++ b/my-app/src/Dashboard.js
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RealisationsList from './RealisationsList';
+
+const API_URL = 'http://localhost:5000/realisations';
+
+function Dashboard() {
+  const [realisations, setRealisations] = useState([]);
+  const navigate = useNavigate();
+  const token = localStorage.getItem('token');
+
+  const loadRealisations = async () => {
+    try {
+      const response = await fetch(API_URL, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      const data = await response.json();
+      setRealisations(data);
+    } catch (err) {
+      console.error('Erreur chargement réalisations', err);
+    }
+  };
+
+  useEffect(() => {
+    loadRealisations();
+  }, []);
+
+  const handleDelete = async (id) => {
+    try {
+      await fetch(`${API_URL}/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      loadRealisations();
+    } catch (err) {
+      console.error('Erreur suppression réalisation', err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <button onClick={() => navigate('/dashboard/new')}>Ajouter une réalisation</button>
+      <RealisationsList
+        realisations={realisations}
+        onEdit={(r) => navigate(`/dashboard/edit/${r.id}`)}
+        onDelete={handleDelete}
+      />
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/my-app/src/RealisationFormPage.js
+++ b/my-app/src/RealisationFormPage.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import RealisationForm from './RealisationForm';
+
+const API_URL = 'http://localhost:5000/realisations';
+
+function RealisationFormPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [initialData, setInitialData] = useState(null);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    if (id) {
+      const load = async () => {
+        try {
+          const response = await fetch(`${API_URL}/${id}`, {
+            headers: { Authorization: `Bearer ${token}` }
+          });
+          const data = await response.json();
+          setInitialData(data);
+        } catch (err) {
+          console.error('Erreur chargement réalisation', err);
+        }
+      };
+      load();
+    }
+  }, [id, token]);
+
+  const handleSubmit = async (realisation) => {
+    try {
+      const method = id ? 'PUT' : 'POST';
+      const url = id ? `${API_URL}/${id}` : API_URL;
+      await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(realisation)
+      });
+      navigate('/dashboard');
+    } catch (err) {
+      console.error('Erreur sauvegarde réalisation', err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>{id ? 'Modifier' : 'Ajouter'} une réalisation</h2>
+      <RealisationForm
+        onSubmit={handleSubmit}
+        initialData={initialData}
+        onCancel={() => navigate('/dashboard')}
+      />
+    </div>
+  );
+}
+
+export default RealisationFormPage;


### PR DESCRIPTION
## Summary
- implement admin login storing JWT token
- add dashboard for managing realisations with links to form
- show admin navigation button only when authenticated

## Testing
- `npm test --silent` (fails: Cannot find module 'react-router-dom')
- `npm test` in my-api (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b582bb97888320bb6f0e686a3a03b6