### PR TITLE
feat: integrate Bootstrap and Sass with SCSS structure

### DIFF
--- a/my-app/package.json
+++ b/my-app/package.json
@@ -7,10 +7,12 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "bootstrap": "^5.3.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^6.23.0",
     "react-scripts": "5.0.1",
+    "sass": "^1.77.6",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -8,7 +8,6 @@ import AdminLogin from './AdminLogin';
 import Dashboard from './Dashboard';
 import RealisationFormPage from './RealisationFormPage';
 import NavBar from './components/NavBar';
-import './App.css';
 
 function App() {
   const [token, setToken] = useState(localStorage.getItem('token'));

--- a/my-app/src/index.js
+++ b/my-app/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './styles/main.scss';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/my-app/src/styles/_app.scss
+++ b/my-app/src/styles/_app.scss
@@ -36,3 +36,4 @@
     transform: rotate(360deg);
   }
 }
+

--- a/my-app/src/styles/_base.scss
+++ b/my-app/src/styles/_base.scss
@@ -16,3 +16,4 @@ body.dark-mode {
   background-color: #121212;
   color: #ffffff;
 }
+

--- a/my-app/src/styles/main.scss
+++ b/my-app/src/styles/main.scss
@@ -1,0 +1,3 @@
+@import './base';
+@import './app';
+


### PR DESCRIPTION
## Summary
- add Bootstrap and Sass dependencies
- migrate global styles to SCSS and import via main.scss
- load Bootstrap and SCSS in app entry point

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found as dependencies could not be installed)*


------
https://chatgpt.com/codex/tasks/task_e_68b5850721648320b8f3d7fda2b9cda3