### PR TITLE
feat: add Express API with JWT and MySQL

### DIFF
--- a/my-api/package.json
+++ b/my-api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Api pour un site web vitrine CRUD",
   "main": "index.js",
-   "scripts": {
+  "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
     "dev": "nodemon server.js"
@@ -15,6 +15,7 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "mysql": "^2.18.1",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "jsonwebtoken": "^9.0.2"
   }
 }

--- a/my-api/server.js
+++ b/my-api/server.js
@@ -1,0 +1,104 @@
+require('dotenv').config();
+const express = require('express');
+const cors = require('cors');
+const mysql = require('mysql');
+const jwt = require('jsonwebtoken');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const db = mysql.createConnection({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_NAME
+});
+
+db.connect(err => {
+  if (err) {
+    console.error('Database connection error:', err);
+    return;
+  }
+  console.log('Connected to MySQL');
+});
+
+function verifyToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ message: 'Token manquant' });
+  }
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) {
+      return res.status(403).json({ message: 'Token invalide' });
+    }
+    req.user = user;
+    next();
+  });
+}
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const sql = 'SELECT * FROM users WHERE username = ? AND password = ?';
+  db.query(sql, [username, password], (err, results) => {
+    if (err) {
+      return res.status(500).json({ error: err });
+    }
+    if (results.length === 0) {
+      return res.status(401).json({ message: 'Identifiants invalides' });
+    }
+    const user = { id: results[0].id, username: results[0].username };
+    const token = jwt.sign(user, process.env.JWT_SECRET, { expiresIn: '1h' });
+    res.json({ token });
+  });
+});
+
+app.get('/realisations', (req, res) => {
+  const sql = 'SELECT * FROM realisations';
+  db.query(sql, (err, results) => {
+    if (err) {
+      return res.status(500).json({ error: err });
+    }
+    res.json(results);
+  });
+});
+
+app.post('/realisations', verifyToken, (req, res) => {
+  const data = req.body;
+  const sql = 'INSERT INTO realisations SET ?';
+  db.query(sql, data, (err, result) => {
+    if (err) {
+      return res.status(500).json({ error: err });
+    }
+    res.status(201).json({ id: result.insertId, ...data });
+  });
+});
+
+app.put('/realisations/:id', verifyToken, (req, res) => {
+  const { id } = req.params;
+  const data = req.body;
+  const sql = 'UPDATE realisations SET ? WHERE id = ?';
+  db.query(sql, [data, id], (err) => {
+    if (err) {
+      return res.status(500).json({ error: err });
+    }
+    res.json({ id, ...data });
+  });
+});
+
+app.delete('/realisations/:id', verifyToken, (req, res) => {
+  const { id } = req.params;
+  const sql = 'DELETE FROM realisations WHERE id = ?';
+  db.query(sql, [id], (err) => {
+    if (err) {
+      return res.status(500).json({ error: err });
+    }
+    res.status(204).end();
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- scaffold Express server with CORS and JSON parsing
- add REST endpoints for login and realisations with JWT guard
- declare jsonwebtoken dependency

## Testing
- `npm test`
- `node server.js` *(fails: Cannot find module 'jsonwebtoken')*

------
https://chatgpt.com/codex/tasks/task_e_68b5862e6c388320a95b544c1dae85e4