### PR TITLE
feat: centralize API service and refresh data

### DIFF
--- a/my-app/src/AdminLogin.js
+++ b/my-app/src/AdminLogin.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-const LOGIN_URL = 'http://localhost:5000/login';
+import { login } from './services/api';
 
 function AdminLogin({ onLogin }) {
   const [email, setEmail] = useState('');
@@ -11,15 +10,7 @@ function AdminLogin({ onLogin }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const response = await fetch(LOGIN_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      });
-      if (!response.ok) {
-        throw new Error('Erreur de connexion');
-      }
-      const data = await response.json();
+      const data = await login({ email, password });
       localStorage.setItem('token', data.token);
       onLogin && onLogin(data.token);
       navigate('/dashboard');

--- a/my-app/src/Dashboard.js
+++ b/my-app/src/Dashboard.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import RealisationsList from './RealisationsList';
-
-const API_URL = 'http://localhost:5000/realisations';
+import { getRealisations, deleteRealisation } from './services/api';
 
 function Dashboard() {
   const [realisations, setRealisations] = useState([]);
@@ -11,10 +10,7 @@ function Dashboard() {
 
   const loadRealisations = async () => {
     try {
-      const response = await fetch(API_URL, {
-        headers: { Authorization: `Bearer ${token}` }
-      });
-      const data = await response.json();
+      const data = await getRealisations(token);
       setRealisations(data);
     } catch (err) {
       console.error('Erreur chargement réalisations', err);
@@ -27,10 +23,7 @@ function Dashboard() {
 
   const handleDelete = async (id) => {
     try {
-      await fetch(`${API_URL}/${id}`, {
-        method: 'DELETE',
-        headers: { Authorization: `Bearer ${token}` }
-      });
+      await deleteRealisation(id, token);
       loadRealisations();
     } catch (err) {
       console.error('Erreur suppression réalisation', err);

--- a/my-app/src/RealisationFormPage.js
+++ b/my-app/src/RealisationFormPage.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import RealisationForm from './RealisationForm';
-
-const API_URL = 'http://localhost:5000/realisations';
+import { getRealisation, saveRealisation } from './services/api';
 
 function RealisationFormPage() {
   const { id } = useParams();
@@ -14,10 +13,7 @@ function RealisationFormPage() {
     if (id) {
       const load = async () => {
         try {
-          const response = await fetch(`${API_URL}/${id}`, {
-            headers: { Authorization: `Bearer ${token}` }
-          });
-          const data = await response.json();
+          const data = await getRealisation(id, token);
           setInitialData(data);
         } catch (err) {
           console.error('Erreur chargement réalisation', err);
@@ -29,16 +25,7 @@ function RealisationFormPage() {
 
   const handleSubmit = async (realisation) => {
     try {
-      const method = id ? 'PUT' : 'POST';
-      const url = id ? `${API_URL}/${id}` : API_URL;
-      await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
-        },
-        body: JSON.stringify(realisation)
-      });
+      await saveRealisation(realisation, token, id);
       navigate('/dashboard');
     } catch (err) {
       console.error('Erreur sauvegarde réalisation', err);

--- a/my-app/src/Realisations.js
+++ b/my-app/src/Realisations.js
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import RealisationsList from './RealisationsList';
 import RealisationForm from './RealisationForm';
-
-const API_URL = 'http://localhost:5000/realisations';
+import {
+  getRealisations,
+  saveRealisation,
+  deleteRealisation
+} from './services/api';
 
 function Realisations() {
   const [realisations, setRealisations] = useState([]);
@@ -10,8 +13,7 @@ function Realisations() {
 
   const loadRealisations = async () => {
     try {
-      const response = await fetch(API_URL);
-      const data = await response.json();
+      const data = await getRealisations();
       setRealisations(data);
     } catch (err) {
       console.error('Erreur chargement réalisations', err);
@@ -24,13 +26,7 @@ function Realisations() {
 
   const handleSubmit = async (realisation) => {
     try {
-      const method = editing ? 'PUT' : 'POST';
-      const url = editing ? `${API_URL}/${editing.id}` : API_URL;
-      await fetch(url, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(realisation),
-      });
+      await saveRealisation(realisation, null, editing && editing.id);
       setEditing(null);
       loadRealisations();
     } catch (err) {
@@ -40,7 +36,7 @@ function Realisations() {
 
   const handleDelete = async (id) => {
     try {
-      await fetch(`${API_URL}/${id}`, { method: 'DELETE' });
+      await deleteRealisation(id);
       loadRealisations();
     } catch (err) {
       console.error('Erreur suppression réalisation', err);

--- a/my-app/src/pages/Contact.jsx
+++ b/my-app/src/pages/Contact.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { sendContact } from '../services/api';
 
 const Contact = () => {
   const [name, setName] = useState('');
@@ -9,20 +10,12 @@ const Contact = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const response = await fetch('http://localhost:5000/contact', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, email, message })
-      });
+      await sendContact({ name, email, message });
 
-      if (response.ok) {
-        setNotification({ type: 'success', text: 'Votre message a été envoyé.' });
-        setName('');
-        setEmail('');
-        setMessage('');
-      } else {
-        setNotification({ type: 'danger', text: "Une erreur s'est produite. Veuillez réessayer." });
-      }
+      setNotification({ type: 'success', text: 'Votre message a été envoyé.' });
+      setName('');
+      setEmail('');
+      setMessage('');
     } catch (err) {
       setNotification({ type: 'danger', text: "Une erreur s'est produite. Veuillez réessayer." });
     }

--- a/my-app/src/services/api.js
+++ b/my-app/src/services/api.js
@@ -1,0 +1,67 @@
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+
+const apiFetch = async (endpoint, options = {}) => {
+  try {
+    const response = await fetch(`${API_URL}${endpoint}`, options);
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Erreur API');
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('API error:', error);
+    throw error;
+  }
+};
+
+export const login = (credentials) =>
+  apiFetch('/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(credentials)
+  });
+
+export const getRealisations = (token) =>
+  apiFetch('/realisations', {
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  });
+
+export const getRealisation = (id, token) =>
+  apiFetch(`/realisations/${id}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  });
+
+export const saveRealisation = (realisation, token, id) =>
+  apiFetch(id ? `/realisations/${id}` : '/realisations', {
+    method: id ? 'PUT' : 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {})
+    },
+    body: JSON.stringify(realisation)
+  });
+
+export const deleteRealisation = (id, token) =>
+  apiFetch(`/realisations/${id}`, {
+    method: 'DELETE',
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  });
+
+export const sendContact = (payload) =>
+  apiFetch('/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+export default {
+  login,
+  getRealisations,
+  getRealisation,
+  saveRealisation,
+  deleteRealisation,
+  sendContact
+};


### PR DESCRIPTION
## Summary
- add reusable API service for auth, contacts, and réalisations
- replace direct fetch calls with centralized helpers
- refresh réalisations list after create/update/delete

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b5960fb27c8320a657fb373b0a1bc0