### PR TITLE
chore: unify API port to 5000

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ npm start
 | `PORT` | Port d'écoute de l'API |
 | `REACT_APP_API_URL` | URL de l'API consommée par l'application React |
 
+### Port par défaut
+
+Le projet utilise le port **5000** pour l'API. L'application React consomme cette API via l'URL `http://localhost:5000` définie dans `REACT_APP_API_URL`.
+
 ## Scripts disponibles
 
 ### API (`my-api`)

--- a/my-api/server.js
+++ b/my-api/server.js
@@ -98,7 +98,7 @@ app.delete('/realisations/:id', verifyToken, (req, res) => {
   });
 });
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- default API port set to 5000
- document port choice and API URL in README

## Testing
- `cd my-api && npm test` *(fails: Error: no test specified)*
- `cd my-app && npm install --no-audit --no-fund` *(fails: 403 Forbidden - bootstrap)*
- `cd my-app && npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59bed721c8320ab8423e9f4f4ff69