### PR TITLE
Use email for admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ npm start
 
 Le projet utilise le port **5000** pour l'API. L'application React consomme cette API via l'URL `http://localhost:5000` définie dans `REACT_APP_API_URL`.
 
+## Authentification administrateur
+
+L'espace d'administration utilise désormais l'**email** et le mot de passe de l'utilisateur pour se connecter.
+
+### Migration de la table `users`
+
+Une migration SQL est fournie pour renommer la colonne `username` en `email` et ajouter une contrainte d'unicité :
+
+```sql
+ALTER TABLE users
+  CHANGE COLUMN username email VARCHAR(255) NOT NULL,
+  ADD UNIQUE KEY unique_email (email);
+```
+
+Exécuter cette migration avec :
+
+```bash
+mysql -u <user> -p <db_name> < my-api/migrations/001_use_email_for_admin.sql
+```
+
 ## Scripts disponibles
 
 ### API (`my-api`)

--- a/my-api/migrations/001_use_email_for_admin.sql
+++ b/my-api/migrations/001_use_email_for_admin.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+  CHANGE COLUMN username email VARCHAR(255) NOT NULL,
+  ADD UNIQUE KEY unique_email (email);

--- a/my-api/server.js
+++ b/my-api/server.js
@@ -39,16 +39,16 @@ function verifyToken(req, res, next) {
 }
 
 app.post('/login', (req, res) => {
-  const { username, password } = req.body;
-  const sql = 'SELECT * FROM users WHERE username = ? AND password = ?';
-  db.query(sql, [username, password], (err, results) => {
+  const { email, password } = req.body;
+  const sql = 'SELECT * FROM users WHERE email = ? AND password = ?';
+  db.query(sql, [email, password], (err, results) => {
     if (err) {
       return res.status(500).json({ error: err });
     }
     if (results.length === 0) {
       return res.status(401).json({ message: 'Identifiants invalides' });
     }
-    const user = { id: results[0].id, username: results[0].username };
+    const user = { id: results[0].id, email: results[0].email };
     const token = jwt.sign(user, process.env.JWT_SECRET, { expiresIn: '1h' });
     res.json({ token });
   });

--- a/my-app/src/AdminLogin.js
+++ b/my-app/src/AdminLogin.js
@@ -3,14 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import { login } from './services/api';
 
 function AdminLogin({ onLogin }) {
-  const [email, setEmail] = useState('');
+  const [loginEmail, setLoginEmail] = useState('');
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const data = await login({ email, password });
+      const data = await login({ email: loginEmail, password });
       localStorage.setItem('token', data.token);
       onLogin && onLogin(data.token);
       navigate('/dashboard');
@@ -24,9 +24,9 @@ function AdminLogin({ onLogin }) {
       <h2>Connexion Admin</h2>
       <input
         type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Adresse e-mail"
+        value={loginEmail}
+        onChange={(e) => setLoginEmail(e.target.value)}
         required
       />
       <input


### PR DESCRIPTION
## Summary
- Switch admin authentication to use email address
- Rename admin login field and add database migration for email column
- Document new login requirements and migration steps

## Testing
- `cd my-api && npm test` (fails: Error: no test specified)
- `cd my-app && npm install` (fails: 403 Forbidden)
- `cd my-app && npm test` (fails: react-scripts: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b59d55e3bc8320a245c11787a95def