### PR TITLE
Add route to fetch realisation by ID and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Les champs sont validés et nettoyés avant l'enregistrement en base de données
 - `400` : données invalides.
 - `500` : erreur serveur.
 
+## Réalisations
+
+L'API fournit une route `GET /realisations/:id` pour récupérer une réalisation spécifique.
+
+### Réponses
+
+- `200` : réalisation trouvée.
+- `404` : réalisation introuvable.
+- `500` : erreur serveur.
+
 ## Scripts disponibles
 
 ### API (`my-api`)

--- a/my-api/server.js
+++ b/my-api/server.js
@@ -105,6 +105,20 @@ app.get('/realisations', (req, res) => {
   });
 });
 
+app.get('/realisations/:id', (req, res) => {
+  const { id } = req.params;
+  const sql = 'SELECT * FROM realisations WHERE id = ?';
+  db.query(sql, [id], (err, results) => {
+    if (err) {
+      return res.status(500).json({ error: err });
+    }
+    if (results.length === 0) {
+      return res.status(404).json({ message: 'R\u00e9alisation introuvable' });
+    }
+    res.json(results[0]);
+  });
+});
+
 app.post('/realisations', verifyToken, (req, res) => {
   const data = req.body;
   const sql = 'INSERT INTO realisations SET ?';


### PR DESCRIPTION
## Summary
- add API route to fetch a single realisation by ID, returning 404 when absent
- document the `/realisations/:id` route in the README

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b59fcc254c83208b418c1a2094c5b0