### PR TITLE
feat: add responsive mixins and styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,14 @@ site-vitrine-exemple1/
 ├── LICENSE
 └── README.md
 ```
+
+## Breakpoints CSS
+
+Les mixins SCSS utilisent les largeurs suivantes :
+
+| Nom | Largeur minimale |
+|-----|------------------|
+| `sm` | 576 px |
+| `md` | 768 px |
+| `lg` | 992 px |
+| `xl` | 1200 px |

--- a/my-app/src/APropos.js
+++ b/my-app/src/APropos.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 function APropos() {
   return (
-    <div className="container mt-4">
+    <div className="container section">
       <div className="row justify-content-center">
         <div className="col-12 col-md-8 text-center">
-          <h2 className="mb-3">À propos</h2>
-          <p className="mb-0">À propos de nous.</p>
+          <h2 className="title">À propos</h2>
+          <p>À propos de nous.</p>
         </div>
       </div>
     </div>

--- a/my-app/src/AdminLogin.js
+++ b/my-app/src/AdminLogin.js
@@ -20,24 +20,26 @@ function AdminLogin({ onLogin }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="admin-login-form">
-      <h2>Connexion Admin</h2>
-      <input
-        type="email"
-        placeholder="Adresse e-mail"
-        value={loginEmail}
-        onChange={(e) => setLoginEmail(e.target.value)}
-        required
-      />
-      <input
-        type="password"
-        placeholder="Mot de passe"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        required
-      />
-      <button type="submit">Se connecter</button>
-    </form>
+    <div className="section">
+      <form onSubmit={handleSubmit} className="admin-login-form">
+        <h2 className="title">Connexion Admin</h2>
+        <input
+          type="email"
+          placeholder="Adresse e-mail"
+          value={loginEmail}
+          onChange={(e) => setLoginEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit" className="btn-custom">Se connecter</button>
+      </form>
+    </div>
   );
 }
 

--- a/my-app/src/Dashboard.js
+++ b/my-app/src/Dashboard.js
@@ -31,9 +31,11 @@ function Dashboard() {
   };
 
   return (
-    <div>
-      <h2>Dashboard</h2>
-      <button onClick={() => navigate('/dashboard/new')}>Ajouter une réalisation</button>
+    <div className="section">
+      <h2 className="title">Dashboard</h2>
+      <button className="btn-custom" onClick={() => navigate('/dashboard/new')}>
+        Ajouter une réalisation
+      </button>
       <RealisationsList
         realisations={realisations}
         onEdit={(r) => navigate(`/dashboard/edit/${r.id}`)}

--- a/my-app/src/RealisationForm.js
+++ b/my-app/src/RealisationForm.js
@@ -58,9 +58,9 @@ function RealisationForm({ onSubmit, initialData, onCancel }) {
         onChange={handleChange}
         required
       />
-      <button type="submit">Enregistrer</button>
+      <button type="submit" className="btn-custom">Enregistrer</button>
       {onCancel && (
-        <button type="button" onClick={onCancel}>
+        <button type="button" className="btn-custom" onClick={onCancel}>
           Annuler
         </button>
       )}

--- a/my-app/src/RealisationFormPage.js
+++ b/my-app/src/RealisationFormPage.js
@@ -33,8 +33,8 @@ function RealisationFormPage() {
   };
 
   return (
-    <div>
-      <h2>{id ? 'Modifier' : 'Ajouter'} une réalisation</h2>
+    <div className="section">
+      <h2 className="title">{id ? 'Modifier' : 'Ajouter'} une réalisation</h2>
       <RealisationForm
         onSubmit={handleSubmit}
         initialData={initialData}

--- a/my-app/src/Realisations.js
+++ b/my-app/src/Realisations.js
@@ -18,10 +18,10 @@ function Realisations() {
   }, []);
 
   return (
-    <div className="container mt-4">
-      <div className="row mb-4">
+    <div className="container section">
+      <div className="row">
         <div className="col-12 text-center">
-          <h2>Réalisations</h2>
+          <h2 className="title">Réalisations</h2>
         </div>
       </div>
       <RealisationsList realisations={realisations} />

--- a/my-app/src/RealisationsList.js
+++ b/my-app/src/RealisationsList.js
@@ -6,33 +6,31 @@ function RealisationsList({ realisations, onEdit, onDelete }) {
   }
 
   return (
-    <div className="row">
+    <div className="responsive-grid">
       {realisations.map((realisation) => (
-        <div key={realisation.id} className="col-12 col-md-6 col-lg-4 mb-4">
-          <div className="p-3 h-100 border text-center">
-            <h3 className="h5 mb-2">{realisation.title}</h3>
-            <p className="mb-2">{realisation.content}</p>
-            {realisation.image && (
-              <img
-                src={realisation.image}
-                alt={realisation.title}
-                className="img-fluid mb-2"
-              />
-            )}
-            <p className="mb-2">
-              {realisation.date ? new Date(realisation.date).toLocaleDateString() : ''}
-            </p>
-            {onEdit && (
-              <button className="btn btn-sm btn-primary me-2" onClick={() => onEdit(realisation)}>
-                Modifier
-              </button>
-            )}
-            {onDelete && (
-              <button className="btn btn-sm btn-danger" onClick={() => onDelete(realisation.id)}>
-                Supprimer
-              </button>
-            )}
-          </div>
+        <div key={realisation.id} className="p-3 h-100 border text-center">
+          <h3 className="h5 mb-2">{realisation.title}</h3>
+          <p className="mb-2">{realisation.content}</p>
+          {realisation.image && (
+            <img
+              src={realisation.image}
+              alt={realisation.title}
+              className="img-fluid mb-2"
+            />
+          )}
+          <p className="mb-2">
+            {realisation.date ? new Date(realisation.date).toLocaleDateString() : ''}
+          </p>
+          {onEdit && (
+            <button className="btn btn-sm btn-primary me-2" onClick={() => onEdit(realisation)}>
+              Modifier
+            </button>
+          )}
+          {onDelete && (
+            <button className="btn btn-sm btn-danger" onClick={() => onDelete(realisation.id)}>
+              Supprimer
+            </button>
+          )}
         </div>
       ))}
     </div>

--- a/my-app/src/Services.js
+++ b/my-app/src/Services.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 function Services() {
   return (
-    <div className="container mt-4">
+    <div className="container section">
       <div className="row justify-content-center">
         <div className="col-12 col-md-8 text-center">
-          <h2 className="mb-3">Services</h2>
-          <p className="mb-0">Nos services.</p>
+          <h2 className="title">Services</h2>
+          <p>Nos services.</p>
         </div>
       </div>
     </div>

--- a/my-app/src/pages/Contact.jsx
+++ b/my-app/src/pages/Contact.jsx
@@ -22,7 +22,7 @@ const Contact = () => {
   };
 
   return (
-    <div className="container mt-4 section">
+    <div className="container section">
       <div className="row justify-content-center mb-4">
         <div className="col-12 text-center">
           <h2 className="title">Contact</h2>

--- a/my-app/src/styles/_app.scss
+++ b/my-app/src/styles/_app.scss
@@ -42,11 +42,27 @@
 }
 
 .section {
-  @include section;
+  @include section($spacing-sm);
+  @include respond(md) {
+    padding: $spacing-md;
+    margin-bottom: $spacing-lg;
+  }
+  @include respond(lg) {
+    padding: $spacing-lg;
+  }
 }
 
 .title {
-  @include title;
+  @include title(1.5rem);
+  @include respond(md) {
+    font-size: 2rem;
+  }
+  @include respond(lg) {
+    font-size: 2.5rem;
+  }
+  @include respond(xl) {
+    font-size: 3rem;
+  }
 }
 
 .form-control {
@@ -60,5 +76,20 @@
   &:invalid {
     border-color: $danger-color;
     box-shadow: 0 0 0 0.2rem rgba($danger-color, 0.25);
+  }
+}
+
+.responsive-grid {
+  display: grid;
+  gap: $spacing-md;
+  grid-template-columns: 1fr;
+  @include respond(md) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @include respond(lg) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  @include respond(xl) {
+    grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/my-app/src/styles/_mixins.scss
+++ b/my-app/src/styles/_mixins.scss
@@ -21,3 +21,14 @@
   color: $color;
   margin-bottom: $spacing-md;
 }
+
+@mixin respond($breakpoint) {
+  $size: map-get($breakpoints, $breakpoint);
+  @if $size {
+    @media (min-width: $size) {
+      @content;
+    }
+  } @else {
+    @warn 'Breakpoint not found: #{$breakpoint}';
+  }
+}

--- a/my-app/src/styles/_variables.scss
+++ b/my-app/src/styles/_variables.scss
@@ -6,3 +6,10 @@ $font-family: 'Helvetica, Arial, sans-serif';
 $spacing-sm: 8px;
 $spacing-md: 16px;
 $spacing-lg: 24px;
+
+$breakpoints: (
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px
+);


### PR DESCRIPTION
## Summary
- add SCSS breakpoint mixin `respond` with sm, md, lg, xl sizes
- apply responsive font, spacing, and grid styles across pages
- document available breakpoints in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bootstrap)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm install` *(my-api, fails: 403 Forbidden - GET https://registry.npmjs.org/bcrypt)*
- `npm test --silent` *(my-api, fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b638fbb48320a573893393e03fd4